### PR TITLE
support using kinetic heap with UF set cost

### DIFF
--- a/include/zombie/config.hpp
+++ b/include/zombie/config.hpp
@@ -14,6 +14,12 @@ struct ZombieConfig {
   KineticHeapImpl heap;
   TockTreeImpl tree;
   AffMetric metric;
+  // for some varying metric, such as those concerning UF set,
+  // the aff function in [Trailokya::book] may not be up-to-date.
+  // when the actual value is within [1/approx_factor, approx_factor] of the stored value,
+  // we ignore the difference
+  // [approx_factor] is stored as a rational number here. it must be greater than 1.
+  std::pair<unsigned int, unsigned int> approx_factor;
 };
 
 
@@ -39,4 +45,4 @@ inline AffFunction uf_metric(Time last_accessed, Time cost, Time neighbor_cost, 
   };
 }
 
-constexpr ZombieConfig default_config = ZombieConfig { KineticHeapImpl::Bag, TockTreeImpl::Tree, &local_metric };
+constexpr ZombieConfig default_config = ZombieConfig { KineticHeapImpl::Bag, TockTreeImpl::Tree, &local_metric, {1, 1} };

--- a/include/zombie/heap/bag.hpp
+++ b/include/zombie/heap/bag.hpp
@@ -51,6 +51,7 @@ public:
       if (min_idx >= vec.size() || vec[i].f(time_) <= vec[min_idx].f(time_))
         min_idx = i;
 
+    assert(min_idx < vec.size());
     return min_idx;
   }
 
@@ -68,6 +69,11 @@ public:
   }
 
   T remove(size_t i) {
+    if (i == 0 && vec.size() == 1) {
+      T t = std::move(vec.back().t);
+      vec.pop_back();
+      return t;
+    }
     std::swap(vec[i], vec.back());
     notify(vec[i], i);
     T t = std::move(vec.back().t);

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "zombie/zombie.hpp"
 #include "zombie/heap/heap.hpp"
 
 template<bool is_unique>
@@ -44,4 +45,44 @@ template<bool is_unique>
 struct NotifyIndexChanged {
   void operator()(const Element<is_unique>&, const size_t&) {
   }
+};
+
+
+
+
+
+template<>
+struct GetSize<int> {
+  size_t operator()(const int&) {
+    return sizeof(int);
+  }
+};
+
+
+
+// [test_id] is used to separate different tests
+template<typename test_id>
+struct Resource {
+  static unsigned int count;
+  static unsigned int destructor_count;
+
+  int value;
+
+  Resource(int value) : value(value) { ++count; }
+  Resource(const Resource&) = delete;
+  ~Resource() { --count; ++destructor_count; }
+};
+
+template<typename test_id>
+unsigned int Resource<test_id>::count = 0;
+
+template<typename test_id>
+unsigned int Resource<test_id>::destructor_count = 0;
+
+
+template<typename test_id>
+struct GetSize<Resource<test_id>> {
+  size_t operator()(const Resource<test_id>&) {
+    return 1 << 16;
+  };
 };

--- a/test/uf_test.cc
+++ b/test/uf_test.cc
@@ -1,4 +1,5 @@
 #include "zombie/zombie.hpp"
+#include "common.hpp"
 
 #include <gtest/gtest.h>
 
@@ -18,12 +19,6 @@ namespace UF {
 }
 
 
-template<>
-struct GetSize<int> {
-  size_t operator()(const int&) {
-    return sizeof(int);
-  }
-};
 
 template<typename T, typename U>
 struct GetSize<std::pair<T, U>> {
@@ -160,25 +155,6 @@ TEST(ZombieUFTest, CompareWithLocal) {
 
 
 
-template<typename test_id>
-struct Resource {
-  static unsigned int count;
-
-  int value;
-  Resource(int value) : value(value) { ++count; }
-  Resource(const Resource&) = delete;
-  ~Resource() { --count; }
-};
-
-template<typename test_id>
-unsigned int Resource<test_id>::count = 0;
-
-template<typename test_id>
-struct GetSize<Resource<test_id>> {
-  size_t operator()(const Resource<test_id>&) {
-    return 1 << 16;
-  };
-};
 
 // access a list of zombies with linear dependency, first from beginning to end,
 // then from end to beginning.

--- a/test/uf_test.cc
+++ b/test/uf_test.cc
@@ -2,14 +2,19 @@
 
 #include <gtest/gtest.h>
 
-constexpr ZombieConfig uf_cfg = { default_config.heap, default_config.tree, &uf_cost_metric };
-
-namespace UF {
-  IMPORT_ZOMBIE(uf_cfg)
-}
+constexpr ZombieConfig uf_cost_cfg = { default_config.heap, default_config.tree, &uf_cost_metric, {1, 1} };
+constexpr ZombieConfig uf_cfg = { default_config.heap, default_config.tree, &uf_metric, {1, 1} };
 
 namespace Local {
   IMPORT_ZOMBIE(default_config)
+}
+
+namespace UFCost {
+  IMPORT_ZOMBIE(uf_cost_cfg)
+}
+
+namespace UF {
+  IMPORT_ZOMBIE(uf_cfg)
 }
 
 
@@ -29,7 +34,7 @@ struct GetSize<std::pair<T, U>> {
 
 
 TEST(ZombieUFTest, CalculateTotalCost) {
-  using namespace UF;
+  using namespace UFCost;
   auto& t = Trailokya::get_trailokya();
 
   Zombie<int> z1 = bindZombie([&]() {
@@ -69,7 +74,7 @@ TEST(ZombieUFTest, CalculateTotalCost) {
 
 
 TEST(ZombieUFTest, ReplayChangeCost) {
-  using namespace UF;
+  using namespace UFCost;
   auto& t = Trailokya::get_trailokya();
 
   // z1 -> z2 -> z4 <- z3
@@ -118,70 +123,172 @@ TEST(ZombieUFTest, ReplayChangeCost) {
 
 
 
-// currently this test fails,
-// because aff function in [Trailokya::book] is not correctly updated
 TEST(ZombieUFTest, CompareWithLocal) {
+#define EXAMPLE_CODE \
+    auto& t = Trailokya::get_trailokya();\
+    Zombie<int> z1 = bindZombie([&]() {\
+      t.meter.fast_forward(100s);\
+      return Zombie<int>(1);\
+    });\
+    Zombie<int> z2 = bindZombie([&](int x1) {\
+      t.meter.fast_forward(101s);\
+      return Zombie<int>(x1 + 1);\
+    }, z1);\
+    Zombie<int> z3 = bindZombie([&]() {\
+      t.meter.fast_forward(200s);\
+      return Zombie<int>(3);\
+    });\
+    t.reaper.murder();\
+    EXPECT_TRUE (z1.evicted());\
+    EXPECT_FALSE(z2.evicted() || z3.evicted());\
+    t.reaper.murder();
+
   {
     using namespace Local;
-    auto& t = Trailokya::get_trailokya();
-
-    Zombie<int> z1 = bindZombie([&]() {
-      t.meter.fast_forward(10s);
-      return Zombie<int>(1);
-    });
-    Zombie<int> z2 = bindZombie([&](int x1) {
-      t.meter.fast_forward(11s);
-      return Zombie<int>(x1 + 1);
-    }, z1);
-
-
-    Zombie<int> z3 = bindZombie([&]() {
-      t.meter.fast_forward(20s);
-      return Zombie<int>(4);
-    });
-
-    t.meter.fast_forward(1s);
-
-    t.reaper.murder();
-    EXPECT_TRUE (z1.evicted());
-    EXPECT_FALSE(z2.evicted() || z3.evicted());
-
-    t.reaper.murder();
+    EXAMPLE_CODE
     EXPECT_TRUE (z2.evicted());
     EXPECT_FALSE(z3.evicted());
   }
 
   {
-    using namespace UF;
-    auto& t = Trailokya::get_trailokya();
-
-    Zombie<int> z1 = bindZombie([&]() {
-      t.meter.fast_forward(10s);
-      return Zombie<int>(1);
-    });
-    Zombie<int> z2 = bindZombie([&](int x1) {
-      t.meter.fast_forward(11s);
-      return Zombie<int>(x1 + 1);
-    }, z1);
-
-
-    Zombie<int> z3 = bindZombie([&]() {
-      t.meter.fast_forward(20s);
-      return Zombie<int>(4);
-    });
-
-
-    t.meter.fast_forward(1s);
-
-    t.reaper.murder();
-    EXPECT_TRUE (z1.evicted());
-    EXPECT_FALSE(z2.evicted() || z3.evicted());
-
-    std::cout << t.book.get_aff(0) << std::endl;
-    std::cout << t.book.get_aff(1) << std::endl;
-    t.meter.fast_forward(1s);
-    t.reaper.murder();
+    using namespace UFCost;
+    EXAMPLE_CODE
     EXPECT_TRUE (z3.evicted());
     EXPECT_FALSE(z2.evicted());
   }
+}
+
+
+
+template<typename test_id>
+struct Resource {
+  static unsigned int count;
+
+  int value;
+  Resource(int value) : value(value) { ++count; }
+  Resource(const Resource&) = delete;
+  ~Resource() { --count; }
+};
+
+template<typename test_id>
+unsigned int Resource<test_id>::count = 0;
+
+template<typename test_id>
+struct GetSize<Resource<test_id>> {
+  size_t operator()(const Resource<test_id>&) {
+    return 1 << 16;
+  };
+};
+
+// access a list of zombies with linear dependency, first from beginning to end,
+// then from end to beginning.
+// - total_size: total number of zombies
+// - memory_limit: number of zombies alive
+// - return value: the list of not evicted zombies after the test
+template<typename test_id>
+ns LinearDependencyForwardBackwardTest(unsigned int total_size, unsigned int memory_limit) {
+  assert(total_size > 1);
+  assert(0 < memory_limit && memory_limit <= total_size);
+
+  using namespace UF;
+  auto& t = Trailokya::get_trailokya();
+
+  using Resource = Resource<test_id>;
+
+  std::vector<Zombie<Resource>> zs;
+
+  auto allocate_memory = [&]() {
+    while (Resource::count >= memory_limit)
+      t.reaper.murder();
+  };
+
+
+  ns t0 = t.meter.time();
+  zs.push_back(bindZombie([&]() {
+    allocate_memory();
+    t.meter.fast_forward(100s);
+    return Zombie<Resource>(0);
+  }));
+
+  // forward
+  for (int i = 1; i < total_size; ++i) {
+    zs.push_back(bindZombie([&](const Resource& x) {
+      allocate_memory();
+      t.meter.fast_forward(100s);
+      return Zombie<Resource>(x.value + 1);
+    }, zs[i - 1]));
+  }
+
+
+  // backward
+  for (int i = total_size - 1; i >= 0; --i) {
+    t.meter.fast_forward(10s);
+    Zombie<Resource> z = zs[i];
+    EXPECT_EQ(z.shared_ptr()->get_ref().value, i);
+    EXPECT_FALSE(z.evicted());
+  }
+  ns t1 = t.meter.time();
+
+  while (t.reaper.have_soul())
+    t.reaper.murder();
+
+  return t1 - t0;
+}
+
+
+
+
+
+
+double r_square(const std::vector<double>& data, std::function<double(unsigned int)> f) {
+  double x_avg = 0, y_avg = 0, xy_avg = 0, x2_avg = 0, y2_avg = 0;
+  for (unsigned int i = 0; i < data.size(); ++i) {
+    double x = f(i);
+    double y = data[i];
+    x_avg += x;
+    y_avg += y;
+    xy_avg += x * y;
+    x2_avg += x * x;
+    y2_avg += y * y;
+  }
+  x_avg /= data.size();
+  y_avg /= data.size();
+  xy_avg /= data.size();
+  x2_avg /= data.size();
+  y2_avg /= data.size();
+
+  double nom = xy_avg - x_avg * y_avg;
+  return nom * nom / (x2_avg - x_avg * x_avg) / (y2_avg - y_avg * y_avg);
+}
+
+
+TEST(ZombieUFTest, SqrtSpaceLinearTime) {
+  struct Test {};
+
+  std::vector<double> times;
+  for (int i = 8; i < 20; ++i)
+    times.push_back(LinearDependencyForwardBackwardTest<Test>(i * i, 2 * i) / 100s);
+
+  double r2 = r_square(times, [](unsigned int x) { return x; });
+  EXPECT_LT(0.9, r2);
+  EXPECT_LT(r2, 1.0);
+}
+
+
+
+TEST(ZombieUFTest, LogSpaceNLogNTime) {
+  struct Test {};
+
+  std::vector<double> times;
+  for (int i = 8; i < 20; ++i)
+    times.push_back(LinearDependencyForwardBackwardTest<Test>(pow(2, 0.5 * i), 2 * i) / 100s);
+
+  // FIXME: currently the actual outcome is exponetial time
+  double r2 = r_square(times, [](unsigned int x) {
+    double size = 0.5 * (8 + x);
+    return pow(2, size);
+  });
+  EXPECT_LT(0.9, r2);
+  EXPECT_LT(r2, 1.0);
+
 }


### PR DESCRIPTION
current issue:
- test with `log N` space takes exponential time rather than `N log N`

other changes:
- in #37, `RecomputeLater` is not re-inserted into `Trailokya::book` when recomputation happens. Fixed in this PR