### PR TITLE
parent pointer in TockTree::Node may become dangling pointer during remove

### DIFF
--- a/include/zombie/tock/tree.hpp
+++ b/include/zombie/tock/tree.hpp
@@ -149,7 +149,8 @@ public:
   }
 
   TockTreeData<V>& put(const TockRange& r, const V& v) {
-    return put(r, v);
+    V v_ = v;
+    return put(r, std::move(v_));
   }
 
   TockTreeData<V>& put(const TockRange& r, V&& v) {

--- a/test/tock_tree_test.cc
+++ b/test/tock_tree_test.cc
@@ -80,3 +80,21 @@ void TockTreeTestFilterChildren() {
 TEST(TockTreeTest, FilterChildren) {
   TockTreeTestFilterChildren<TockTreeImpl::Tree>();
 }
+
+template<TockTreeImpl impl>
+void TockTreeTestRemove() {
+  TockTree<impl, int, NotifyParentChanged> tt;
+
+  for (int i = 1; i <= 20; i++) {
+    tt.put({i, 21 - i}, i);
+  }
+
+  for (int i = 18; i >= 2; i--) {
+    tt.remove_precise(i);
+  }
+}
+
+TEST(TockTreeTest, Remove) {
+  TockTreeTestRemove<TockTreeImpl::Tree>();
+}
+


### PR DESCRIPTION
It's the failed test for #55